### PR TITLE
Fix seeking in Kodi Matrix (v19)

### DIFF
--- a/src/modules/Kodi.js
+++ b/src/modules/Kodi.js
@@ -30,6 +30,7 @@ export default class Kodi extends EventTarget {
     // Listen for events from Kodi.
     // We could immediately use the sent information to update the store, but it easier to just do another sync.
     this.api.listen('Application.OnVolumeChanged', () => this.sync());
+    this.api.listen('Player.OnAVStart', () => this.sync());
     this.api.listen('Player.OnPropertyChanged', () => this.sync());
     this.api.listen('Player.OnPlay', () => this.sync());
     this.api.listen('Player.OnPause', () => this.sync());
@@ -125,7 +126,7 @@ export default class Kodi extends EventTarget {
   }
 
   async seek(percentage) {
-    await this.api.send('Player.seek', [this.activePlayerId, percentage]);
+    await this.api.send('Player.Seek', [this.activePlayerId, { percentage }]);
   }
 
   async add(file) {


### PR DESCRIPTION
The `Player.Seek`-endpoint was cleaned up, so we now use the new
call-structure.

See https://kodi.wiki/view/JSON-RPC_API/v12#Player.Seek.

Also fixed display of progress-bar by listening for an additional event.

Fixes #24