### PR TITLE
fix: Update deprecated MDN URLs to new URL structure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 Echo for Kodi lets you share your favorite content with Kodi (XBMC).
 
-Should work with all [WebExtension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) compatible browsers 
+Should work with all [WebExtension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions) compatible browsers 
 including Mozilla Firefox, Google Chrome and Microsoft Edge.
 
 If you want to try a more complete and robust extension, 
@@ -59,7 +59,7 @@ it requires the permission
 
 * to **send you notifications**   
 
-For more information on permissions, visit [developer.mozilla.org](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/permissions).
+For more information on permissions, visit [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
 
 ## Privacy
 


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates broken MDN links.

## Changes
- Old: `developer.mozilla.org/en-US/Add-ons/WebExtensions/...`
- New: `developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/...`

2 links fixed in readme.md